### PR TITLE
docker: Add test environment based on Debian

### DIFF
--- a/docker/.env.dev
+++ b/docker/.env.dev
@@ -1,0 +1,18 @@
+FACTORY=$FACTORY
+AUTH_TOKEN=$USER_TOKEN
+DEVICE_TAG=main
+
+DEV_DIR=$PWD/.device
+SOTA_DIR=$DEV_DIR/sota
+USR_SOTA_DIR=$DEV_DIR/usr.sota
+ETC_SOTA_DIR=$DEV_DIR/etc.sota
+DOCKER_DIR=$DEV_DIR/docker
+
+# /sysroot dir containing ostree repo in /sysroot/ostree/repo
+SYSROOT=$DEV_DIR/sysroot
+BOOTDIR=$DEV_DIR/boot
+
+# /var/lib/docker
+DOCKER_DATA_ROOT=$DOCKER_DIR/data
+
+FIOUP_DOCKER_DIR=$PWD/docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,63 @@
+FROM debian:trixie
+LABEL Description="Fioup testing dockerfile for Debian Trixie"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# It is important to run these in the same RUN command, because otherwise
+# Docker layer caching breaks us
+RUN apt-get update && apt-get -y install --no-install-suggests --no-install-recommends \
+  apt-transport-https \
+  apt-utils \
+  bash \
+  curl \
+  e2fslibs-dev \
+  git \
+  vim \
+  jq \
+  lshw \
+  make \
+  net-tools \
+  psmisc \
+  python-is-python3 \
+  sqlite3 \
+  wget \
+  zip \
+  docker-compose \
+  sudo \
+  shellcheck \
+  python3-docker \
+  golang \
+  python3-pytest
+
+# Add Docker's official GPG key:
+RUN apt-get update && apt-get install -y ca-certificates curl
+RUN install -m 0755 -d /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+RUN chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN apt-get update && apt-get -y install --no-install-suggests --no-install-recommends \
+  docker-ce \
+  docker-ce-cli
+
+# Install docker credential helper and auth configuration
+COPY config.json /usr/lib/docker/config.json
+COPY docker-credential-fioup-helper /usr/bin/docker-credential-fioup-helper
+
+# Install gosu required for the entry/startup script to add a user and group in the container
+RUN wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
+    gosu nobody true
+
+# Copy the entrypoint script
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["bash"]

--- a/docker/config.json
+++ b/docker/config.json
@@ -1,0 +1,6 @@
+{
+        "credHelpers": {
+                "hub.foundries.io": "fioup-helper"
+        }
+}
+

--- a/docker/dev-shell.sh
+++ b/docker/dev-shell.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+docker_dir=docker
+docker_path=${PWD}/${docker_dir}
+
+# Function to execute custom commands before exiting
+down() {
+	docker compose --env-file=${docker_path}/.env.dev -f ${docker_path}/docker-compose.yml down --remove-orphans
+	# remove the docker runtime part
+	docker volume rm ${docker_dir}_docker-runtime
+}
+
+# Register the cleanup function to be called on EXIT
+trap down EXIT
+
+mkdir -p $PWD/.device/sysroot
+docker compose --env-file=${docker_path}/.env.dev -f ${docker_path}/docker-compose.yml run -e DEV_USER=$(id -u) -e DEV_GROUP=$(id -g) -e BASE_TARGET_VERSION=${BASE_TARGET_VERSION} -e USER_TOKEN=${USER_TOKEN} -e TAG=${TAG} fioup-e2e-test "$@"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.8'
+
+services:
+  dockerd:
+    image: ghcr.io/foundriesio/moby:25.0.3_fio
+    command: ["dockerd", "-H", "unix:///var/run/docker/docker.sock"]
+    volumes:
+      - ${DOCKER_DATA_ROOT}:/var/lib/docker
+      - docker-runtime:/var/run/docker
+      - ${SOTA_DIR}:/var/sota
+    privileged: true
+
+  fioup-e2e-test:
+      build:
+        context: ${FIOUP_E2E_TEST_DOCKER_DIR}
+        args:
+          FIOUP_VER: master
+        dockerfile: Dockerfile
+
+      image: fioup-e2e-test
+      volumes:
+        - "${PWD}:${PWD}"
+        - ${SYSROOT}:/sysroot
+        - ${SYSROOT}/ostree:/ostree
+        - ${BOOTDIR}:/boot
+        - ${SOTA_DIR}:/var/sota
+        - ${USR_SOTA_DIR}:/usr/lib/sota/conf.d
+        - ${ETC_SOTA_DIR}:/etc/sota/conf.d
+        - ${DOCKER_DATA_ROOT}:/var/lib/docker
+        - docker-runtime:/var/run/docker
+      working_dir: "${PWD}"
+      hostname: device
+      user: "root"
+      environment:
+        - FACTORY=${FACTORY}
+        - AUTH_TOKEN=${AUTH_TOKEN}
+        - DEVICE_TAG=${DEVICE_TAG}
+        - DOCKER_HOST=unix:///var/run/docker/docker.sock
+        - DOCKER_CONFIG=/usr/lib/docker
+      depends_on:
+      - dockerd
+      networks: {}
+
+volumes:
+  docker-runtime:

--- a/docker/docker-credential-fioup-helper
+++ b/docker/docker-credential-fioup-helper
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+
+SOTA_DIR="${SOTA_DIR-/var/sota}"
+
+if [ "$1" = "get" ] ; then
+    if [ ! -f ${SOTA_DIR}/sota.toml ] ; then
+        echo "ERROR: Device does not appear to be registered under $SOTA_DIR"
+        exit 1
+    fi
+    server=$(grep -m1 '^[[:space:]]*server' ${SOTA_DIR}/sota.toml | cut -d\" -f2)
+    if [ -z $server ] ; then
+        server="https://ota-lite.foundries.io:8443"
+    fi
+    exec /usr/local/bin/fioup http get ${server}/hub-creds/
+fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh -e
+
+if [ -z $DEV_USER ] || [ -z $DEV_GROUP ]; then
+    echo "DEV_USER and DEV_GROUP environment variables must be set."
+    exit 1
+fi
+
+# Create a group with the specified GID if it doesn't already exist
+if ! getent group $DEV_GROUP >/dev/null; then
+    groupadd -g $DEV_GROUP devgrp
+fi
+
+# Create a user with the specified UID and GID if it doesn't already exist
+if ! getent passwd $DEV_USER >/dev/null; then
+    useradd -u $DEV_USER -g $DEV_GROUP -m dev
+fi
+
+# Change ownership of the home directory to the appuser
+chown -R dev:devgrp /home/dev
+
+chown dev:devgrp /var/run/docker/docker.sock
+
+chown -R dev:devgrp /var/sota
+chown -R dev:devgrp /usr/lib/sota/conf.d
+chown -R dev:devgrp /etc/sota/conf.d
+chown -R dev:devgrp /var/lib/docker
+
+ln -sfn ${PWD}/bin/fioup /usr/local/bin/fioup
+
+# Run the command as the created user
+exec gosu $DEV_USER:$DEV_GROUP "$@"


### PR DESCRIPTION
Define a docker compose application based on the one used in aktualizr-lite end-to-end tests. It includes a Debian Trixie container with all necessary dependencies installed to build and run fioup tests.