### PR TITLE
register: Define generic amd64/arm64 hardware ids

### DIFF
--- a/internal/register/options.go
+++ b/internal/register/options.go
@@ -38,7 +38,6 @@ type RegisterOptions struct {
 }
 
 const (
-	HARDWARE_ID    = "unknown"
 	LMP_OS_STR     = "/etc/os-release"
 	OS_FACTORY_TAG = "LMP_FACTORY_TAG"
 	OS_FACTORY     = "LMP_FACTORY"

--- a/internal/register/options_amd64.go
+++ b/internal/register/options_amd64.go
@@ -1,0 +1,8 @@
+//go:build amd64
+
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package register
+
+const HARDWARE_ID = "amd64"

--- a/internal/register/options_arm64.go
+++ b/internal/register/options_arm64.go
@@ -1,0 +1,8 @@
+//go:build arm64
+
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package register
+
+const HARDWARE_ID = "arm64"


### PR DESCRIPTION
These are the two platforms we'll be supporting.