### PR TITLE
Hide advanced registration options

### DIFF
--- a/cmd/fioup/register.go
+++ b/cmd/fioup/register.go
@@ -34,6 +34,10 @@ func init() {
 	cmd.Flags().BoolVar(&opt.Force, "force", false, "Force registration, removing data from previous execution.")
 
 	cobra.CheckErr(cmd.Flags().MarkHidden("api-token-header"))
+	cobra.CheckErr(cmd.Flags().MarkHidden("api-token"))
+	cobra.CheckErr(cmd.Flags().MarkHidden("device-group"))
+	cobra.CheckErr(cmd.Flags().MarkHidden("production"))
+	cobra.CheckErr(cmd.Flags().MarkHidden("uuid"))
 
 	rootCmd.AddCommand(cmd)
 }


### PR DESCRIPTION
This might be a little bit controversial. However, as I was trying to stub out our installation documentation, I found that our `fioup register --help` usage statement is still a little overwhelming and presenting options not even supported by the community edition.

I'm happy to debate each option, but I think we need really compelling rationale to show an option. I almost want to remove `--sota-dir` as it takes a bit of time to understand how that interacts with `--cfg-dirs` but I decided that option is the one advanced thing a lot of people will be tempted to use - the support will be *less* by leaving that in.