### PR TITLE
update: Do not try to cancel a failed update during rollback

### DIFF
--- a/internal/update/updates.go
+++ b/internal/update/updates.go
@@ -265,7 +265,7 @@ func rollback(updateContext *UpdateContext) error {
 			if err != nil {
 				log.Err(err).Msg("Rollback: Error updateContext.Runner.Complete")
 			}
-		} else {
+		} else if updateStatus.State != update.StateFailed {
 			err := updateContext.Runner.Cancel(updateContext.Context)
 			if err != nil {
 				log.Err(err).Msg("Rollback: Error updateContext.Runner.Cancel")


### PR DESCRIPTION
Composeapp does not allow a failed update to be canceled. Avoiding it fixes rollabck in fioup.