### PR TITLE
cmd: Remove --src-dir option

### DIFF
--- a/cmd/fioup/update.go
+++ b/cmd/fioup/update.go
@@ -10,7 +10,6 @@ import (
 )
 
 func addCommonOptions(cmd *cobra.Command, opts *update.UpdateOptions) {
-	cmd.Flags().StringVarP(&opts.SrcDir, "src-dir", "s", "", "Directory that contains an offline update bundle.")
 	cmd.Flags().BoolVar(&opts.EnableTuf, "tuf", false, "Enable TUF metadata checking, instead of reading targets.json directly.")
 	_ = cmd.Flags().MarkHidden("tuf")
 }

--- a/internal/update/updates.go
+++ b/internal/update/updates.go
@@ -19,7 +19,6 @@ import (
 
 type (
 	UpdateOptions struct {
-		SrcDir    string
 		EnableTuf bool
 		TargetId  string
 


### PR DESCRIPTION
Feature is not a priority for now, we can re-introduce the option when required.