### PR TITLE
Unify gateway cllient usage

### DIFF
--- a/internal/events/event_sender.go
+++ b/internal/events/event_sender.go
@@ -110,12 +110,7 @@ func FlushEvents(dbFilePath string, client *client.GatewayClient) error {
 	return nil
 }
 
-func NewEventSender(cfg *config.Config) (*EventSender, error) {
-	gwClient, err := client.NewGatewayClient(cfg, nil, "")
-	if err != nil {
-		return nil, err
-	}
-
+func NewEventSender(cfg *config.Config, gwClient *client.GatewayClient) (*EventSender, error) {
 	eventSender := &EventSender{
 		dbPath:   cfg.GetDBPath(),
 		gwClient: gwClient,
@@ -173,10 +168,6 @@ func (s *EventSender) EnqueueEvent(eventType EventTypeValue, updateID string, to
 	var completionStatus *bool
 	if len(success) > 0 {
 		completionStatus = &success[0]
-	}
-	if eventType == InstallationCompleted && completionStatus != nil && *completionStatus {
-		// Update list of apps and target ID if update is successful
-		s.gwClient.UpdateHeaders(toTarget.AppNames(), toTarget.ID)
 	}
 	evt := NewEvent(eventType, "", completionStatus, updateID, toTarget.ID, toTarget.Version)
 	err := SaveEvent(s.dbPath, &evt[0])

--- a/pkg/api/check.go
+++ b/pkg/api/check.go
@@ -64,6 +64,8 @@ func Check(cfg *config.Config, options ...CheckOpt) (target.Targets, error) {
 		currentTarget = targets.GetTargetByID(lastUpdate.ClientRef)
 		if currentTarget.IsUnknown() {
 			slog.Debug("cannot find lastUpdate target in the target list", "target", lastUpdate.ClientRef)
+		} else {
+			currentTarget.ShortlistAppsByURI(lastUpdate.URIs)
 		}
 	}
 	if !currentTarget.IsUnknown() {

--- a/pkg/client/gateway_client.go
+++ b/pkg/client/gateway_client.go
@@ -35,10 +35,14 @@ func NewGatewayClient(cfg *config.Config, apps []string, targetID string) (*Gate
 		return nil, fmt.Errorf("failed to create HTTPS HttpClient to talk to Device Gateway: %w", err)
 	}
 	headers := map[string]string{
-		"user-agent":    UserAgentPrefix + "/1.0.0", // TODO: figure out version and append here
-		HeaderKeyTag:    cfg.GetTag(),
-		HeaderKeyApps:   strings.Join(apps, ","),
-		HeaderKeyTarget: targetID,
+		"user-agent": UserAgentPrefix + "/1.0.0", // TODO: figure out version and append here
+		HeaderKeyTag: cfg.GetTag(),
+	}
+	if apps != nil {
+		headers[HeaderKeyApps] = strings.Join(apps, ",")
+	}
+	if targetID != "" {
+		headers[HeaderKeyTarget] = targetID
 	}
 	return &GatewayClient{
 		BaseURL:    cfg.GetServerBaseURL(),

--- a/pkg/state/check.go
+++ b/pkg/state/check.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/foundriesio/composeapp/pkg/compose"
 	"github.com/foundriesio/composeapp/pkg/update"
-	"github.com/foundriesio/fioup/pkg/client"
 	"github.com/foundriesio/fioup/pkg/target"
 	"github.com/pkg/errors"
 )
@@ -67,12 +66,7 @@ func (s *Check) Execute(ctx context.Context, updateCtx *UpdateContext) error {
 	}
 
 	var targetRepo target.Repo
-	var gwClient *client.GatewayClient
-	gwClient, err = client.NewGatewayClient(updateCtx.Config, updateCtx.FromTarget.AppNames(), updateCtx.FromTarget.ID)
-	if err != nil {
-		return err
-	}
-	targetRepo, err = target.NewPlainRepo(gwClient, updateCtx.Config.GetTargetsFilepath(), updateCtx.Config.GetHardwareID())
+	targetRepo, err = target.NewPlainRepo(updateCtx.Client, updateCtx.Config.GetTargetsFilepath(), updateCtx.Config.GetHardwareID())
 	if err != nil {
 		return err
 	}
@@ -141,6 +135,7 @@ func (s *Check) Execute(ctx context.Context, updateCtx *UpdateContext) error {
 			updateMode, updateCtx.FromTarget.Version, strings.Join(updateCtx.FromTarget.AppNames(), ","),
 			updateCtx.ToTarget.Version, strings.Join(updateCtx.ToTarget.AppNames(), ","))
 	}
+	updateCtx.Client.UpdateHeaders(updateCtx.FromTarget.AppNames(), updateCtx.FromTarget.ID)
 	return nil
 }
 

--- a/pkg/state/start.go
+++ b/pkg/state/start.go
@@ -33,6 +33,7 @@ func (s *Start) Execute(ctx context.Context, updateCtx *UpdateContext) error {
 		if err := updateCtx.UpdateRunner.Complete(ctx, update.CompleteWithPruning()); err != nil {
 			slog.Debug("failed to complete update with pruning", "error", err)
 		}
+		updateCtx.Client.UpdateHeaders(updateCtx.ToTarget.AppNames(), updateCtx.ToTarget.ID)
 	} else {
 		err = fmt.Errorf("%w: %s", ErrStartFailed, err.Error())
 	}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/foundriesio/composeapp/pkg/update"
 	"github.com/foundriesio/fioup/internal/events"
+	"github.com/foundriesio/fioup/pkg/client"
 	"github.com/foundriesio/fioup/pkg/config"
 	"github.com/foundriesio/fioup/pkg/target"
 )
@@ -25,6 +26,7 @@ type (
 	UpdateContext struct {
 		Config      *config.Config
 		EventSender *events.EventSender
+		Client      *client.GatewayClient
 
 		FromTarget   target.Target
 		ToTarget     target.Target

--- a/pkg/state/update_runner.go
+++ b/pkg/state/update_runner.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/foundriesio/fioup/internal/events"
 	internal "github.com/foundriesio/fioup/internal/update"
+	"github.com/foundriesio/fioup/pkg/client"
 	"github.com/foundriesio/fioup/pkg/config"
 	"github.com/foundriesio/fioup/pkg/target"
 )
@@ -39,13 +40,19 @@ func (sm *UpdateRunner) Run(ctx context.Context, cfg *config.Config) error {
 	}
 	sm.ctx.Config = cfg
 
-	eventSender, err := events.NewEventSender(cfg)
+	client, err := client.NewGatewayClient(cfg, nil, "")
+	if err != nil {
+		return err
+	}
+	eventSender, err := events.NewEventSender(cfg, client)
 	if err != nil {
 		return err
 	}
 	eventSender.Start()
 	defer eventSender.Stop()
+
 	sm.ctx.EventSender = eventSender
+	sm.ctx.Client = client
 
 	stateCounter := 1
 	for _, s := range sm.states {


### PR DESCRIPTION
It fixes the issue with removing the current target at the device backend state after the `fetch` command is executed. Also:

Use single instance of gateway client
1. Use the same instance of the gateway client for both:
  - getting targets metadata,
  - sending events.

2. Set the "apps" and "target name" headers once the current status is
   detected (in the check state).

3. Update the "apps" and "target name"  headers once the update was
   successfully started before sending the "completed" event (in the
   "start" state).