### PR TITLE
events: Initialize ticker in main thread

### DIFF
--- a/internal/events/event_sender.go
+++ b/internal/events/event_sender.go
@@ -132,8 +132,8 @@ func (s *EventSender) Start() {
 	s.stopChan = make(chan struct{}, 1)
 	s.flushChan = make(chan struct{}, 1)
 	s.wg.Add(1)
+	s.ticker = time.NewTicker(time.Duration(time.Second * 10))
 	go func(stopChan chan struct{}, flushChan chan struct{}) {
-		s.ticker = time.NewTicker(time.Duration(time.Second * 10))
 		defer s.ticker.Stop()
 		defer s.wg.Done()
 		for {


### PR DESCRIPTION
Ticker was being initialized inside coroutine, which could lead to a race condition in case Start method is called multiple times in parallel.