### PR TITLE
Options to specify gateway client and event sender instances

### DIFF
--- a/pkg/api/update.go
+++ b/pkg/api/update.go
@@ -6,6 +6,8 @@ package api
 import (
 	"context"
 
+	"github.com/foundriesio/fioup/internal/events"
+	"github.com/foundriesio/fioup/pkg/client"
 	"github.com/foundriesio/fioup/pkg/config"
 	"github.com/foundriesio/fioup/pkg/state"
 )
@@ -15,6 +17,7 @@ type (
 		Force       bool
 		SyncCurrent bool
 		MaxAttempts int
+		state.UpdateRunnerOpts
 	}
 	UpdateOpt func(*UpdateOpts)
 )
@@ -34,6 +37,18 @@ func WithSyncCurrent(enabled bool) UpdateOpt {
 func WithMaxAttempts(count int) UpdateOpt {
 	return func(o *UpdateOpts) {
 		o.MaxAttempts = count
+	}
+}
+
+func WithEventSender(sender *events.EventSender) UpdateOpt {
+	return func(o *UpdateOpts) {
+		o.EventSender = sender
+	}
+}
+
+func WithGatewayClient(client *client.GatewayClient) UpdateOpt {
+	return func(o *UpdateOpts) {
+		o.GatewayClient = client
 	}
 }
 
@@ -58,5 +73,8 @@ func Update(ctx context.Context, cfg *config.Config, toVersion int, options ...U
 		&state.Fetch{},
 		&state.Install{},
 		&state.Start{},
+	}, func(r *state.UpdateRunnerOpts) {
+		r.EventSender = opts.EventSender
+		r.GatewayClient = opts.GatewayClient
 	}).Run(ctx, cfg)
 }


### PR DESCRIPTION
In some case, such as the daemon mode/client it makes sense to allow a client to instantiate and control instances of `GatewayClient` and `EventSender`.

Hence, the new options of the `Update` API call are introduced to enable such possibility as well as the daemon implementation is adjusted accordingly.
