### PR TITLE
install: Skip install if started or starting

### DIFF
--- a/pkg/state/install.go
+++ b/pkg/state/install.go
@@ -22,6 +22,11 @@ func (s *Install) Execute(ctx context.Context, updateCtx *UpdateContext) error {
 	} else {
 		fmt.Printf("\n")
 	}
+	currentState := updateCtx.UpdateRunner.Status().State
+	if currentState == update.StateStarted || currentState == update.StateStarting {
+		fmt.Println("\tskipping installation since update has been already installed")
+		return nil
+	}
 	// Stop apps being updated before installing their updates
 	if err := compose.StopApps(ctx, updateCtx.Config.ComposeConfig(), updateCtx.FromTarget.AppURIs()); err != nil {
 		return err


### PR DESCRIPTION
The composeapp state machine doesn't allow running install if the update is in "starting" or "started" state, hence we should skip installation in such the case.