### PR TITLE
fetch: Force update by default

### DIFF
--- a/pkg/api/fetch.go
+++ b/pkg/api/fetch.go
@@ -16,6 +16,7 @@ func Fetch(ctx context.Context, cfg *config.Config, toVersion int) error {
 			Action:         "fetch",
 			UpdateTargets:  false,
 			AllowNewUpdate: true,
+			Force:          true,
 			ToVersion:      toVersion,
 		},
 		&state.Init{},


### PR DESCRIPTION
Always initiate update if the `api.Fetch` is invoked regardless of the current state, even of the specified target is already installed and running.