### PR TITLE
daemon: Adjust installation retry and rollback behavior

### DIFF
--- a/cmd/fioup/daemon.go
+++ b/cmd/fioup/daemon.go
@@ -82,6 +82,13 @@ func doDaemon(cmd *cobra.Command, opts *daemonOptions) {
 				// If cancelation was successful, proceed without waiting
 				continue
 			}
+		} else if err != nil && !errors.Is(err, state.ErrStartFailed) {
+			slog.Info("Error starting updated target", "error", err)
+			if !opts.runOnce {
+				// Retry installation, or do a sync update, without waiting
+				// If runOnce is set, exit execution in the return statement bellow
+				continue
+			}
 		} else if err != nil && !errors.Is(err, state.ErrCheckNoUpdate) {
 			slog.Error("Error during update", "error", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace github.com/theupdateframework/go-tuf/v2 v2.0.2 => github.com/foundriesio
 
 require (
 	github.com/docker/distribution v2.8.2+incompatible
-	github.com/foundriesio/composeapp v0.0.0-20251022082123-45d0288fb396
+	github.com/foundriesio/composeapp v0.0.0-20251027130835-dc7fdc20251a
 	github.com/foundriesio/fioconfig v0.0.0-20250924185146-c3257662fd13
 	github.com/foundriesio/fiotuf v0.0.0-20250811143610-819b20a26cb8
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/foundriesio/composeapp v0.0.0-20251022082123-45d0288fb396 h1:i8CbMHzwKa1UfLoiAjNsBOQgrmSbG9MJ2e1+95dxknc=
-github.com/foundriesio/composeapp v0.0.0-20251022082123-45d0288fb396/go.mod h1:nA95y4iS0RnUV9iAyau91/mv7doDs6eXazEE+Pd53c4=
+github.com/foundriesio/composeapp v0.0.0-20251027130835-dc7fdc20251a h1:xkqMSjeb69WgiTJWBV6gwgKZjuVl6cV169kiM5K04Ik=
+github.com/foundriesio/composeapp v0.0.0-20251027130835-dc7fdc20251a/go.mod h1:nA95y4iS0RnUV9iAyau91/mv7doDs6eXazEE+Pd53c4=
 github.com/foundriesio/fioconfig v0.0.0-20250924185146-c3257662fd13 h1:cjASbFUrNYvsf3zYACPZkpLGTic0674+bRi4USFdZc8=
 github.com/foundriesio/fioconfig v0.0.0-20250924185146-c3257662fd13/go.mod h1:J3pslinCE6G5lqeAU5EY7/KBGKWRTq53P16eUH9zgG4=
 github.com/foundriesio/fiotuf v0.0.0-20250811143610-819b20a26cb8 h1:nL7q+DCc1M925rKSCvZQEwyKxHanjsMBF1kjyRZ9v0U=

--- a/pkg/state/check.go
+++ b/pkg/state/check.go
@@ -130,7 +130,8 @@ func (s *Check) Execute(ctx context.Context, updateCtx *UpdateContext) error {
 				} else {
 					slog.Debug("Checking failed updates count for target", "target_id", updateCtx.ToTarget.ID, "count", count)
 					if count >= s.MaxAttempts {
-						return fmt.Errorf("latest target installation attempts has reached the limit (%d)", s.MaxAttempts)
+						slog.Info("Latest target installation attempts has reached the limit. Syncing current target", "latest_target_id", updateCtx.ToTarget.ID, "count", count)
+						updateCtx.ToTarget = updateCtx.FromTarget
 					}
 				}
 			}


### PR DESCRIPTION
Retry installation imediatelly in daemon when apps have failed to start. After reaching the retries limit (currently set to 3), make the check operation set the current target as installation target, allowing a sync update to be automatically performed.