### PR TITLE
register: Fix logic for installing docker cred helper

### DIFF
--- a/internal/register/docker.go
+++ b/internal/register/docker.go
@@ -11,31 +11,20 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"strings"
 )
 
 func getDockerConfigPath() (string, error) {
-	sudoer := os.Getenv("SUDO_USER")
-	path := ""
-	if len(sudoer) > 0 {
-		u, err := user.Lookup(sudoer)
-		if err != nil {
-			return "", fmt.Errorf("unable to configure docker-credential-helper: %w", err)
-		}
-		path = u.HomeDir
-	} else {
-		var err error
-		path, err = os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("unable to configure docker-credential-helper: %w", err)
-		}
+	errFmt := "unable to configure docker-credential-helper: %w. Please consult documentation for manually configuration steps"
+	path, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf(errFmt, err)
 	}
 	path = filepath.Join(path, ".docker")
 
 	if err := os.Mkdir(path, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
-		return "", fmt.Errorf("unable to configure docker-credential-helper: %w", err)
+		return "", fmt.Errorf(errFmt, err)
 	}
 
 	return path, nil


### PR DESCRIPTION
This logic was copied too well from what we do in Fioctl. In Fioctl we have a different problem; a credential helper needs to be installed and the user probably needs to run `fioctl configure-docker` with `sudo` to allow for that. However, it then needs to *configure* the cred helper for the actual user, `SUDO_USER`.

In the case of fioup, we are wanting to configure as the root user.

In the advanced scenario of running as non-root, this code will contiue to work correctly.