### PR TITLE
daemon: Fix handling of target start errors

### DIFF
--- a/cmd/fioup/daemon.go
+++ b/cmd/fioup/daemon.go
@@ -80,7 +80,7 @@ func doDaemon(cmd *cobra.Command, opts *daemonOptions) {
 				// If cancelation was successful, proceed without waiting
 				continue
 			}
-		} else if err != nil && !errors.Is(err, state.ErrStartFailed) {
+		} else if err != nil && errors.Is(err, state.ErrStartFailed) {
 			slog.Info("Error starting updated target", "error", err)
 			if !opts.runOnce {
 				// Retry installation, or do a sync update, without waiting


### PR DESCRIPTION
Incorrect handling was leading to an infinite update loop after once the system has the latest target and no update is required.