### PR TITLE
check: Determine and use app diff consistently.

### DIFF
--- a/pkg/state/check.go
+++ b/pkg/state/check.go
@@ -182,10 +182,6 @@ func (u *UpdateContext) isUpdateRequired(ctx context.Context) bool {
 
 func (u *UpdateContext) isTargetInSync(ctx context.Context) (bool, error) {
 	slog.Debug("Checking target", "target_id", u.ToTarget.ID)
-	if len(u.ToTarget.Apps) == 0 {
-		slog.Debug("No required apps to check")
-		return true, nil
-	}
 	if u.checkAppDiff() {
 		// There is some difference between a list of apps in FromTarget and ToTarget
 		// and taking into account the enabled apps in the config


### PR DESCRIPTION
Use the `AppDiff` value of the update context to determine whether the "from" and "to" app lists differ which in turn is used to determine if an update is needed for the sync case.