### PR TITLE
debian: Add dependency on "docker compose"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,8 @@ Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
          lshw,
-         docker.io
+         docker.io,
+         docker-compose
 Static-Built-Using: ${misc:Static-Built-Using}
 Description: OTA Update Client for FoundriesFactory™
  A command-line utility for performing over-the-air (OTA) updates of


### PR DESCRIPTION
Installing "docker.io" does not lead to "docker-compose" installation, so this dependency has to be specified explicitly.