### PR TITLE
fioconfig: Bump to 0c6d0ac

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/theupdateframework/go-tuf/v2 v2.0.2 => github.com/foundriesio
 require (
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/foundriesio/composeapp v0.0.0-20251027130835-dc7fdc20251a
-	github.com/foundriesio/fioconfig v0.0.0-20251027173311-a6cdf8755c05
+	github.com/foundriesio/fioconfig v0.0.0-20251101194105-0c6d0ac7e118
 	github.com/foundriesio/fiotuf v0.0.0-20250811143610-819b20a26cb8
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/foundriesio/composeapp v0.0.0-20251027130835-dc7fdc20251a h1:xkqMSjeb69WgiTJWBV6gwgKZjuVl6cV169kiM5K04Ik=
 github.com/foundriesio/composeapp v0.0.0-20251027130835-dc7fdc20251a/go.mod h1:nA95y4iS0RnUV9iAyau91/mv7doDs6eXazEE+Pd53c4=
-github.com/foundriesio/fioconfig v0.0.0-20251027173311-a6cdf8755c05 h1:PM6hxoLFpaQRyYJAh8Z50giTVacdzwjBR/l/F4zMfio=
-github.com/foundriesio/fioconfig v0.0.0-20251027173311-a6cdf8755c05/go.mod h1:3cLFsAyngsCwvXgtt+JgU170oKmJQIvoktvT7gQALE8=
+github.com/foundriesio/fioconfig v0.0.0-20251101194105-0c6d0ac7e118 h1:6bGiWDTXxAuJm2+lFuIfoE5bqbS5Y9XUyMYZHLY5jMs=
+github.com/foundriesio/fioconfig v0.0.0-20251101194105-0c6d0ac7e118/go.mod h1:3cLFsAyngsCwvXgtt+JgU170oKmJQIvoktvT7gQALE8=
 github.com/foundriesio/fiotuf v0.0.0-20250811143610-819b20a26cb8 h1:nL7q+DCc1M925rKSCvZQEwyKxHanjsMBF1kjyRZ9v0U=
 github.com/foundriesio/fiotuf v0.0.0-20250811143610-819b20a26cb8/go.mod h1:FgQ6Kc6zP1/+sEXbJjl76WwcCyPe/KrYuCNdkNz0cW0=
 github.com/foundriesio/go-ecies v0.3.0 h1:6Pb71NGo0HKi/5FeVuEHB01Y89OWvrgBBEQWfC9Vv5c=


### PR DESCRIPTION
Includes:
- transport: Avoid exception when printing warning after http error