### PR TITLE
events: Log error when trying to flush events on stopped sender

### DIFF
--- a/internal/events/event_sender.go
+++ b/internal/events/event_sender.go
@@ -179,5 +179,9 @@ func (s *EventSender) EnqueueEvent(eventType EventTypeValue, updateID string, to
 }
 
 func (s *EventSender) FlushEventsAsync() {
+	if s.flushChan == nil {
+		slog.Error("Requested events flush on stopped sender")
+		return
+	}
 	s.flushChan <- struct{}{}
 }


### PR DESCRIPTION
Also avoid using channel if the sender is stopped, which would cause the process to hang.

---

There is an issue, still not solved, with how we re-create the event sender and use it in the update logic that is hitting this error.

Cause is at
https://github.com/foundriesio/fioup/blob/6e02b353bb50cfdd22d34ce08c9d905ca296ea6c/cmd/fioup/daemon.go#L172
and
https://github.com/foundriesio/fioup/blob/6e02b353bb50cfdd22d34ce08c9d905ca296ea6c/cmd/fioup/daemon.go#L181

The reference passed to `api.Update` is stopped, a new one is created and started, but `api.Update` keeps the old reference. 
