### PR TITLE
docker: Persist home directory for dev user

### DIFF
--- a/test/docker/.env.dev
+++ b/test/docker/.env.dev
@@ -7,6 +7,7 @@ SOTA_DIR=$DEV_DIR/sota
 USR_SOTA_DIR=$DEV_DIR/usr.sota
 ETC_SOTA_DIR=$DEV_DIR/etc.sota
 DOCKER_DIR=$DEV_DIR/docker
+HOME_DIR=$DEV_DIR/home
 
 # /sysroot dir containing ostree repo in /sysroot/ostree/repo
 SYSROOT=$DEV_DIR/sysroot

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -28,6 +28,7 @@ services:
         - ${ETC_SOTA_DIR}:/etc/sota/conf.d
         - ${DOCKER_DATA_ROOT}:/var/lib/docker
         - docker-runtime:/var/run/docker
+        - ${HOME_DIR}:/home/dev
       working_dir: "${PWD}"
       hostname: device
       user: "root"

--- a/test/docker/entrypoint.sh
+++ b/test/docker/entrypoint.sh
@@ -12,7 +12,7 @@ fi
 
 # Create a user with the specified UID and GID if it doesn't already exist
 if ! getent passwd $DEV_USER >/dev/null; then
-    useradd -u $DEV_USER -g $DEV_GROUP -m dev
+    useradd -u $DEV_USER -g $DEV_GROUP -d /home/dev dev
 fi
 
 # Change ownership of the home directory to the appuser


### PR DESCRIPTION
This allows docker credentials helper configuration to persist between runs.