### PR TITLE
release: Install deb package with its dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           make deb DEBS_DIR=/tmp/debs
 
           # sanity check
-          sudo dpkg -i /tmp/debs/fioup_*.deb
+          sudo apt update && apt install -y /tmp/debs/fioup_*.deb
           /usr/bin/fioup --help
 
           # linting


### PR DESCRIPTION
Install the built fioup deb package by using "apt" instead "dpkg" in order to auto-install its dependencies, specifically, "docker.io" and "docker-compose".