### PR TITLE
version: Fix and extend version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,18 @@ LINTER = golangci-lint
 TAGS = disable_pkcs11
 DEBS_DIR ?= $(BUILD_DIR)
 
+PKG := main
+VERSION := $(shell git describe --tags --always --dirty)
+COMMIT  := $(shell git rev-parse --short HEAD)
+DATE    := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+LDFLAGS := -X '$(PKG).Version=$(VERSION)' -X '$(PKG).Commit=$(COMMIT)' -X '$(PKG).Date=$(DATE)'
+
 .PHONY: all build clean test format manpages bash-completion
 
 all: build manpages bash-completion
 
 build:
-	@go build -o $(BUILD_DIR)/$(BINARY_NAME) -tags $(TAGS) $(MAIN)
+	@go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME) -tags $(TAGS) $(MAIN)
 
 manpages:
 	@go run -tags disable_pkcs11,disable_main $(MAIN) manpages $(BUILD_DIR)/man

--- a/cmd/fioup/root.go
+++ b/cmd/fioup/root.go
@@ -42,7 +42,7 @@ var (
 
 			logger := slog.New(handler)
 			slog.SetDefault(logger)
-			if cmd.Name() != "register" {
+			if cmd.Name() != "register" && cmd.Name() != "version" {
 				// Load configuration unless the "register" command is invoked
 				var err error
 				config, err = cfg.NewConfig(configPaths)

--- a/cmd/fioup/version.go
+++ b/cmd/fioup/version.go
@@ -3,21 +3,71 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
-var Commit string
+var (
+	Version string
+	Commit  string
+	Date    string
+)
+
+type (
+	VersionInfo struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+		Date    string `json:"build_date"`
+	}
+
+	versionOptions struct {
+		Format string
+		Short  bool
+	}
+)
 
 func init() {
+	opts := versionOptions{}
+
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Display version of this tool",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(Commit)
-		},
-		Args: cobra.NoArgs,
+		Short: "Print the version information",
+		Args:  cobra.NoArgs,
 	}
+
+	cmd.Flags().StringVar(&opts.Format, "format", "text", "Format the output. Values: [text | json]")
+	cmd.Flags().BoolVar(&opts.Short, "short", false, "Print only the version number")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		info := VersionInfo{
+			Version: Version,
+			Commit:  Commit,
+			Date:    Date,
+		}
+		switch opts.Format {
+		case "json":
+			var data []byte
+			var err error
+			if opts.Short {
+				data, err = json.Marshal(info.Version)
+			} else {
+				data, err = json.MarshalIndent(info, "", "  ")
+			}
+			DieNotNil(err, "failed to marshal version info")
+			fmt.Println(string(data))
+		case "text":
+			if opts.Short {
+				fmt.Println(info.Version)
+			} else {
+				fmt.Printf("Version: %s\nCommit: %s\nBuild Date: %s\n", info.Version, info.Commit, info.Date)
+			}
+		default:
+			return fmt.Errorf("invalid value for --format: %s (must be text or json)", opts.Format)
+		}
+		return nil
+	}
+
 	rootCmd.AddCommand(cmd)
 }


### PR DESCRIPTION
- Extend the output of the version command.
- Set the version related fields during build time.