### PR TITLE
Change polling_seconds value type to string

### DIFF
--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -27,5 +27,5 @@ configured in `/var/sota/sota.toml` by adding:
 
 ```
 [uptane]
-polling_seconds = 60
+polling_seconds = "60"
 ```


### PR DESCRIPTION
If you don't use "" you get this error:

Nov 21 14:20:27 raul systemd[1]: Started fioup.service - Foundries IO Update Client.
Nov 21 14:20:27 raul fioup[8481]: time=2025-11-21T14:20:27.633Z level=INFO msg="Daemon starting" pid=8481
Nov 21 14:20:31 raul fioup[8481]: panic: interface conversion: interface {} is int64, not string
Nov 21 14:20:31 raul fioup[8481]: goroutine 1 [running]:
Nov 21 14:20:31 raul fioup[8481]: github.com/foundriesio/fioconfig/sotatoml.AppConfig.Get({{0x12406c0, 0x3, 0x3}, {0x4000333900, 0x2, 0x2}}, {0xa4e9cb, 0x16})
Nov 21 14:20:31 raul fioup[8481]:         /home/builder/go/pkg/mod/github.com/foundriesio/fioconfig@v0.0.0-20251101194105-0c6d0ac7e118/sotatoml/app_config.go:107 +0xec
Nov 21 14:20:31 raul fioup[8481]: github.com/foundriesio/fioconfig/sotatoml.AppConfig.GetDefault(...)
Nov 21 14:20:31 raul fioup[8481]:         /home/builder/go/pkg/mod/github.com/foundriesio/fioconfig@v0.0.0-20251101194105-0c6d0ac7e118/sotatoml/app_config.go:129
Nov 21 14:20:31 raul fioup[8481]: main.(*updater).reload(0x400058fa60, 0x28?)
Nov 21 14:20:31 raul fioup[8481]:         /src/fioup/cmd/fioup/daemon.go:93 +0x2e0
Nov 21 14:20:31 raul fioup[8481]: main.NewUpdater(...)
Nov 21 14:20:31 raul fioup[8481]:         /src/fioup/cmd/fioup/daemon.go:62
Nov 21 14:20:31 raul fioup[8481]: main.doDaemon(0x4000365508, {0x27?, {{0xa46f02?, 0x0?}, 0x0?, 0x0?}})
Nov 21 14:20:31 raul fioup[8481]:         /src/fioup/cmd/fioup/daemon.go:111 +0x1f4
Nov 21 14:20:31 raul fioup[8481]: main.init.4.func1(0x4000365508?, {0x127b860?, 0x4?, 0xa42cdf?})
Nov 21 14:20:31 raul fioup[8481]:         /src/fioup/cmd/fioup/daemon.go:49 +0x34
Nov 21 14:20:31 raul fioup[8481]: github.com/spf13/cobra.(*Command).execute(0x4000365508, {0x127b860, 0x0, 0x0})
Nov 21 14:20:31 raul fioup[8481]:         /home/builder/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1019 +0x82c
Nov 21 14:20:31 raul fioup[8481]: github.com/spf13/cobra.(*Command).ExecuteC(0x1249340)
Nov 21 14:20:31 raul fioup[8481]:         /home/builder/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148 +0x384
Nov 21 14:20:31 raul fioup[8481]: github.com/spf13/cobra.(*Command).Execute(...)
Nov 21 14:20:31 raul fioup[8481]:         /home/builder/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1071
Nov 21 14:20:31 raul fioup[8481]: main.Execute()
Nov 21 14:20:31 raul fioup[8481]:         /src/fioup/cmd/fioup/root.go:76 +0x278
Nov 21 14:20:31 raul fioup[8481]: main.main()
Nov 21 14:20:31 raul fioup[8481]:         /src/fioup/cmd/fioup/main.go:14 +0x1c
Nov 21 14:20:31 raul systemd[1]: fioup.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Nov 21 14:20:31 raul systemd[1]: fioup.service: Failed with result 'exit-code'.