### PR TITLE
systemd: Let fioup create a runtime directory in /run

### DIFF
--- a/debian/fioup.service
+++ b/debian/fioup.service
@@ -6,3 +6,4 @@ Requires=boot-complete.target
 [Service]
 User=root
 ExecStart=/usr/bin/fioup daemon
+RuntimeDirectory=secrets


### PR DESCRIPTION
Ensure the /run/secrets directory is created so the fioup daemon will start from a fresh install