### PR TITLE
Allow fioup service to be enabled for boot

### DIFF
--- a/debian/fioup.service
+++ b/debian/fioup.service
@@ -6,3 +6,6 @@ Requires=boot-complete.target
 [Service]
 User=root
 ExecStart=/usr/bin/fioup daemon
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
systemd needs an install section in the service file, to allow a service to be enabled to run at boot