### PR TITLE
cmd: Ensure single instance of fioup when needed

### DIFF
--- a/cmd/fioup/cancel.go
+++ b/cmd/fioup/cancel.go
@@ -21,6 +21,9 @@ func init() {
 			doCancel(cmd)
 		},
 		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			lockFlagKey: "true",
+		},
 	}
 	rootCmd.AddCommand(cmd)
 }

--- a/cmd/fioup/check.go
+++ b/cmd/fioup/check.go
@@ -19,6 +19,9 @@ func init() {
 			doCheck(cmd, &opts)
 		},
 		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			lockFlagKey: "true",
+		},
 	}
 	addCommonOptions(cmd, &opts)
 	rootCmd.AddCommand(cmd)

--- a/cmd/fioup/config_check.go
+++ b/cmd/fioup/config_check.go
@@ -54,6 +54,9 @@ func init() {
 			doCheckConfig(cmd, &opts)
 		},
 		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			lockFlagKey: "true",
+		},
 	}
 	opts.ApplyToCmd(cmd)
 	rootCmd.AddCommand(cmd)

--- a/cmd/fioup/config_extract.go
+++ b/cmd/fioup/config_extract.go
@@ -17,6 +17,9 @@ func init() {
 			doConfigExtract(cmd, &opts)
 		},
 		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			lockFlagKey: "true",
+		},
 	}
 	opts.ApplyToCmd(cmd)
 	rootCmd.AddCommand(cmd)

--- a/cmd/fioup/daemon.go
+++ b/cmd/fioup/daemon.go
@@ -49,6 +49,9 @@ func init() {
 			doDaemon(cmd, opts)
 		},
 		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			lockFlagKey: "true",
+		},
 	}
 	cmd.Flags().BoolVar(&opts.configEnabled, "fioconfig", true, "Include fioconfig daemon logic.")
 	opts.fioconfig.ApplyToCmd(cmd)

--- a/cmd/fioup/fetch.go
+++ b/cmd/fioup/fetch.go
@@ -37,6 +37,9 @@ func init() {
 			doFetch(cmd, &opts)
 		},
 		Args: cobra.RangeArgs(0, 1),
+		Annotations: map[string]string{
+			lockFlagKey: "true",
+		},
 	}
 	rootCmd.AddCommand(cmd)
 }

--- a/cmd/fioup/install.go
+++ b/cmd/fioup/install.go
@@ -17,6 +17,9 @@ func init() {
 			doInstall(cmd)
 		},
 		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			lockFlagKey: "true",
+		},
 	}
 	rootCmd.AddCommand(cmd)
 }

--- a/cmd/fioup/register.go
+++ b/cmd/fioup/register.go
@@ -25,6 +25,9 @@ func init() {
 			cobra.CheckErr(err)
 			doRegister(&opt)
 		},
+		Annotations: map[string]string{
+			lockFlagKey: "true",
+		},
 	}
 	cmd.Flags().BoolVar(&opt.Production, "production", false, "Mark the device as a production device.")
 	cmd.Flags().StringVar(&opt.SotaDir, "sota-dir", register.SOTA_DIR, "The directory to install to keys and configuration to.")

--- a/cmd/fioup/run_and_report.go
+++ b/cmd/fioup/run_and_report.go
@@ -37,6 +37,9 @@ func init() {
 			doRunAndReport(cmd, args, &opts)
 		},
 		Args: cobra.MinimumNArgs(1),
+		Annotations: map[string]string{
+			lockFlagKey: "true",
+		},
 	}
 	opts.ApplyToCmd(cmd)
 	rootCmd.AddCommand(cmd)

--- a/cmd/fioup/start.go
+++ b/cmd/fioup/start.go
@@ -17,6 +17,9 @@ func init() {
 			doStart(cmd)
 		},
 		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			lockFlagKey: "true",
+		},
 	}
 	rootCmd.AddCommand(cmd)
 }

--- a/cmd/fioup/update.go
+++ b/cmd/fioup/update.go
@@ -43,6 +43,9 @@ func init() {
 			doUpdate(cmd, &opts)
 		},
 		Args: cobra.RangeArgs(0, 1),
+		Annotations: map[string]string{
+			lockFlagKey: "true",
+		},
 	}
 
 	cmd.Flags().BoolVar(&opts.syncCurrent, "sync-current", false, "Sync the currently installed target if no version is specified.")


### PR DESCRIPTION
Prevent multiple concurrent executions of the fioup CLI commands that can change a state (e.g. update the target list or update status), otherwise it cal lead to undefined behavior and/or results.

- Acquire exclusive flock in PersistentPreRunE if the lock flag is set.
- Store the lock file descriptor globally to keep the lock active.
- The lock is released automatically on process exit.