### PR TITLE
Add support for satellite server

### DIFF
--- a/pkg/api/update_runner.go
+++ b/pkg/api/update_runner.go
@@ -91,6 +91,16 @@ func (sm *UpdateRunner) Run(ctx context.Context, cfg *config.Config) error {
 		slog.Debug("failed to report apps states", "error", err)
 	}
 
+	if proxy, err := sm.ctx.Client.AppsProxyUrl(); err != nil {
+		return fmt.Errorf("failed to get apps proxy URL: %w", err)
+	} else if proxy != nil {
+		if err := proxy.Configure(sm.ctx.Config.ComposeConfig()); err != nil {
+			return fmt.Errorf("failed to configure apps proxy: %w", err)
+		}
+		slog.Debug("using apps proxy", "url", proxy.Url)
+		defer proxy.Unconfigure(sm.ctx.Config.ComposeConfig())
+	}
+
 	sm.ctx.TotalStates = len(sm.states)
 	sm.ctx.CurrentStateNum = 1
 	for _, s := range sm.states {

--- a/pkg/client/apps_proxy.go
+++ b/pkg/client/apps_proxy.go
@@ -1,0 +1,51 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/foundriesio/fioconfig/transport"
+)
+
+type AppsProxy struct {
+	Url    string
+	CaCert string
+}
+
+// Configurre sets environment variables required by composectl to use the proxy
+func (p AppsProxy) Configure() {
+	os.Setenv("COMPOSE_APPS_PROXY", p.Url)
+	os.Setenv("COMPOSE_APPS_PROXY_CA", p.CaCert)
+}
+
+// Unconfigure unsets environment variables used for the apps proxy
+func (p AppsProxy) Unconfigure() {
+	os.Unsetenv("COMPOSE_APPS_PROXY")
+	os.Unsetenv("COMPOSE_APPS_PROXY_CA")
+}
+
+// AppsProxyUrl will look to see if an apps proxy server is configured. If so,
+// it will request a proxy URL from that resource and return it.
+// Returns nil if no proxy server is configured or an error if there
+// was an issue requesting the URL.
+func (c *GatewayClient) AppsProxyUrl() (*AppsProxy, error) {
+	if len(c.proxyAppsUrl) == 0 {
+		return nil, nil
+	}
+
+	resp, err := transport.HttpDo(c.HttpClient, http.MethodPost, c.proxyAppsUrl, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request apps proxy URL: %w", err)
+	} else if resp.StatusCode != 201 {
+		return nil, fmt.Errorf("unexpected response code %d requesting apps proxy URL: %s", resp.StatusCode, resp.String())
+	}
+
+	return &AppsProxy{
+		Url:    resp.String(),
+		CaCert: c.proxyAppsCa,
+	}, nil
+}

--- a/pkg/client/apps_proxy.go
+++ b/pkg/client/apps_proxy.go
@@ -4,28 +4,35 @@
 package client
 
 import (
+	"crypto/x509"
 	"fmt"
 	"net/http"
-	"os"
+	"net/url"
 
+	"github.com/foundriesio/composeapp/pkg/compose"
 	"github.com/foundriesio/fioconfig/transport"
 )
 
 type AppsProxy struct {
 	Url    string
-	CaCert string
+	CaCert *x509.CertPool
 }
 
 // Configurre sets environment variables required by composectl to use the proxy
-func (p AppsProxy) Configure() {
-	os.Setenv("COMPOSE_APPS_PROXY", p.Url)
-	os.Setenv("COMPOSE_APPS_PROXY_CA", p.CaCert)
+func (p AppsProxy) Configure(cfg *compose.Config) error {
+	proxyURL, err := url.Parse(p.Url)
+	if err != nil {
+		return err
+	}
+	cfg.ProxyURL = proxyURL
+	cfg.ProxyCerts = p.CaCert
+	return nil
 }
 
 // Unconfigure unsets environment variables used for the apps proxy
-func (p AppsProxy) Unconfigure() {
-	os.Unsetenv("COMPOSE_APPS_PROXY")
-	os.Unsetenv("COMPOSE_APPS_PROXY_CA")
+func (p AppsProxy) Unconfigure(cfg *compose.Config) {
+	cfg.ProxyURL = nil
+	cfg.ProxyCerts = nil
 }
 
 // AppsProxyUrl will look to see if an apps proxy server is configured. If so,

--- a/pkg/client/gateway_client.go
+++ b/pkg/client/gateway_client.go
@@ -25,6 +25,9 @@ type (
 		HttpClient *http.Client
 		Headers    map[string]string
 
+		proxyAppsUrl string
+		proxyAppsCa  string
+
 		lastNetInfoFile   string
 		lastSotaFile      string
 		sotaToReport      []byte
@@ -98,6 +101,9 @@ func NewGatewayClient(cfg *config.Config, apps []string, targetID string, option
 		BaseURL:    cfg.GetServerBaseURL(),
 		HttpClient: client,
 		Headers:    headers,
+
+		proxyAppsUrl: cfg.TomlConfig().Get("pacman.apps_proxy_server"),
+		proxyAppsCa:  cfg.TomlConfig().Get("import.tls_cacert_path"),
 
 		lastNetInfoFile:   filepath.Join(sota, ".last-netinfo"),
 		lastSotaFile:      filepath.Join(sota, ".last-sota"),

--- a/pkg/client/gateway_client.go
+++ b/pkg/client/gateway_client.go
@@ -102,8 +102,8 @@ func NewGatewayClient(cfg *config.Config, apps []string, targetID string, option
 		HttpClient: client,
 		Headers:    headers,
 
-		proxyAppsUrl: cfg.TomlConfig().Get("pacman.apps_proxy_server"),
-		proxyAppsCa:  cfg.TomlConfig().Get("import.tls_cacert_path"),
+		proxyAppsUrl: cfg.GetComposeAppsProxy(),
+		proxyAppsCa:  cfg.GetComposeAppsProxyCA(),
 
 		lastNetInfoFile:   filepath.Join(sota, ".last-netinfo"),
 		lastSotaFile:      filepath.Join(sota, ".last-sota"),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,8 @@ const (
 	StorageDirKey         = "storage.path"
 	HardwareIDKey         = "provision.primary_ecu_hardware_id"
 	StorageUsageWatermark = "pacman.storage_watermark" // in percentage of overall storage, the maximum allowed to be used by apps
+	ComposeAppsProxyKey   = "pacman.compose_apps_proxy"
+	ServerCACertKey       = "import.tls_cacert_path"
 
 	StorageDefaultDir               = "/var/sota"
 	TargetsDefaultFilename          = "targets.json"
@@ -135,6 +137,14 @@ func (c *Config) GetEnabledApps() []string {
 
 func (c *Config) GetStorageUsageWatermark() uint {
 	return c.storageWatermark
+}
+
+func (c *Config) GetComposeAppsProxy() string {
+	return c.tomlConfig.Get(ComposeAppsProxyKey)
+}
+
+func (c *Config) GetComposeAppsProxyCA() string {
+	return c.TomlConfig().Get(ServerCACertKey)
 }
 
 func newComposeConfig(config *sotatoml.AppConfig) (*compose.Config, error) {

--- a/pkg/state/fetch.go
+++ b/pkg/state/fetch.go
@@ -45,8 +45,11 @@ func (s *Fetch) Execute(ctx context.Context, updateCtx *UpdateContext) error {
 				return fmt.Errorf("failed to get apps proxy URL: %w", err)
 			} else if proxy != nil {
 				slog.Debug("using apps proxy", "url", proxy.Url)
-				proxy.Configure()
-				defer proxy.Unconfigure()
+				if err := proxy.Configure(updateCtx.Config.ComposeConfig()); err != nil {
+					return fmt.Errorf("failed to configure apps proxy: %w", err)
+				} else {
+					defer proxy.Unconfigure(updateCtx.Config.ComposeConfig())
+				}
 			}
 
 			err = updateCtx.UpdateRunner.Fetch(ctx, compose.WithFetchProgress(s.ProgressHandler))

--- a/pkg/state/fetch.go
+++ b/pkg/state/fetch.go
@@ -41,6 +41,14 @@ func (s *Fetch) Execute(ctx context.Context, updateCtx *UpdateContext) error {
 		// Send download started event regardless if there is enough space or not to mark the start of download attempt
 		updateCtx.SendEvent(events.DownloadStarted)
 		if err == nil {
+			if proxy, err := updateCtx.Client.AppsProxyUrl(); err != nil {
+				return fmt.Errorf("failed to get apps proxy URL: %w", err)
+			} else if proxy != nil {
+				slog.Debug("using apps proxy", "url", proxy.Url)
+				proxy.Configure()
+				defer proxy.Unconfigure()
+			}
+
 			err = updateCtx.UpdateRunner.Fetch(ctx, compose.WithFetchProgress(s.ProgressHandler))
 			// Update storage usage info after fetch to reflect actual usage
 			if err := updateCtx.getAndSetStorageUsageInfo(); err != nil {

--- a/pkg/state/fetch.go
+++ b/pkg/state/fetch.go
@@ -41,17 +41,6 @@ func (s *Fetch) Execute(ctx context.Context, updateCtx *UpdateContext) error {
 		// Send download started event regardless if there is enough space or not to mark the start of download attempt
 		updateCtx.SendEvent(events.DownloadStarted)
 		if err == nil {
-			if proxy, err := updateCtx.Client.AppsProxyUrl(); err != nil {
-				return fmt.Errorf("failed to get apps proxy URL: %w", err)
-			} else if proxy != nil {
-				slog.Debug("using apps proxy", "url", proxy.Url)
-				if err := proxy.Configure(updateCtx.Config.ComposeConfig()); err != nil {
-					return fmt.Errorf("failed to configure apps proxy: %w", err)
-				} else {
-					defer proxy.Unconfigure(updateCtx.Config.ComposeConfig())
-				}
-			}
-
 			err = updateCtx.UpdateRunner.Fetch(ctx, compose.WithFetchProgress(s.ProgressHandler))
 			// Update storage usage info after fetch to reflect actual usage
 			if err := updateCtx.getAndSetStorageUsageInfo(); err != nil {


### PR DESCRIPTION
The satellite server includes an endpoint for downloading an "apps proxy" that can be used by composectl to bypass the configured docker registry for app downloads and instead use the satellite server.