### PR TITLE
config: Add proxy support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace github.com/theupdateframework/go-tuf/v2 v2.0.2 => github.com/foundriesio
 
 require (
 	github.com/docker/distribution v2.8.2+incompatible
-	github.com/foundriesio/composeapp v0.0.0-20251210141902-6a356d0f24de
+	github.com/foundriesio/composeapp v0.0.0-20251217143356-4f79b3b0b796
 	github.com/foundriesio/fioconfig v0.0.0-20251212233306-87efd8b30ea1
 	github.com/foundriesio/fiotuf v0.0.0-20250811143610-819b20a26cb8
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/foundriesio/composeapp v0.0.0-20251210141902-6a356d0f24de h1:8zWo+TNYYuPe/2fC0fZObk/RD25AH+GhrwJF3uZqqo8=
-github.com/foundriesio/composeapp v0.0.0-20251210141902-6a356d0f24de/go.mod h1:nA95y4iS0RnUV9iAyau91/mv7doDs6eXazEE+Pd53c4=
+github.com/foundriesio/composeapp v0.0.0-20251217143356-4f79b3b0b796 h1:uQl92UnMn7IPOkTbEgrk0goMaSEvpiif56DjEMD+7Ig=
+github.com/foundriesio/composeapp v0.0.0-20251217143356-4f79b3b0b796/go.mod h1:nA95y4iS0RnUV9iAyau91/mv7doDs6eXazEE+Pd53c4=
 github.com/foundriesio/fioconfig v0.0.0-20251212233306-87efd8b30ea1 h1:pLb6YVUIXSNdL2Lrnk/a8KICSyS0VGhqkZLBFVBN+Xw=
 github.com/foundriesio/fioconfig v0.0.0-20251212233306-87efd8b30ea1/go.mod h1:3cLFsAyngsCwvXgtt+JgU170oKmJQIvoktvT7gQALE8=
 github.com/foundriesio/fiotuf v0.0.0-20250811143610-819b20a26cb8 h1:nL7q+DCc1M925rKSCvZQEwyKxHanjsMBF1kjyRZ9v0U=

--- a/pkg/client/gateway_client.go
+++ b/pkg/client/gateway_client.go
@@ -110,6 +110,7 @@ func NewGatewayClient(cfg *config.Config, apps []string, targetID string, option
 	gw.initSota(cfg.TomlConfig())
 	gw.initHwinfo()
 	gw.initAppStateReporter()
+	cfg.SetClientForProxy(client)
 	return gw, nil
 }
 


### PR DESCRIPTION
Add ability to specify an app proxy server to fetch apps from, and if set request apps from it.
It is needed for the satellite use-case.