### PR TITLE
Add factory name to the "whoami" command

### DIFF
--- a/cmd/fioup/whoami.go
+++ b/cmd/fioup/whoami.go
@@ -36,6 +36,7 @@ func doWhoAmI() {
 	if whoamiFormat == "text" {
 		fmt.Println("Name:     ", self.Name)
 		fmt.Println("Uuuid:    ", self.Uuid)
+		fmt.Println("Factory:  ", self.Factory)
 		fmt.Println("Tag:      ", self.Tag)
 		fmt.Println("Last seen:", self.LastSeen.AsTime())
 		fmt.Println("Created:  ", self.CreatedAt.AsTime())

--- a/pkg/client/self.go
+++ b/pkg/client/self.go
@@ -14,6 +14,7 @@ func (ts DgTimeStamp) AsTime() time.Time {
 }
 
 type Device struct {
+	Factory   string      `json:"factory"`
 	RepoId    string      `json:"repo_id"`
 	Uuid      string      `json:"uuid"`
 	Name      string      `json:"name"`


### PR DESCRIPTION
Display the factory information in the whoami command output. It is quite useful to know a factory name if you have more than two factories.