### PR TITLE
cmd: Print runtime lock related message as debug

### DIFF
--- a/cmd/fioup/root.go
+++ b/cmd/fioup/root.go
@@ -113,7 +113,7 @@ func acquireLock() error {
 func runtimeLockDir() string {
 	// If running as root (including via sudo), use /run
 	if os.Geteuid() == 0 {
-		fmt.Println("Running as root, using /run for runtime lock directory")
+		slog.Debug("Running as root, using /run for runtime lock directory")
 		if _, err := os.Stat("/run"); err == nil {
 			return "/run"
 		}


### PR DESCRIPTION
This avoids always outputting the message, which breaks json output.