### PR TITLE
status: last update: change completed update to use UpdatedAt

### DIFF
--- a/cmd/fioup/status.go
+++ b/cmd/fioup/status.go
@@ -88,7 +88,7 @@ func doStatus(cmd *cobra.Command, opts *statusOptions) {
 	if ongoing {
 		fmt.Printf("  Updated at:\t%s\n", us.StartTime.Local().Format(time.DateTime))
 	} else {
-		fmt.Printf("  Completed at:\t%s\n", us.StartTime.Local().Format(time.DateTime))
+		fmt.Printf("  Completed at:\t%s\n", us.UpdatedAt.Local().Format(time.DateTime))
 	}
 
 	fmt.Println("  Apps:")


### PR DESCRIPTION
In the "Last update status" area, if an update is NOT ongoing, show the UpdatedAt field instead of the StartTime field for "Completed at" value.  Otherwise the start time and completed time will always look the same.