### PR TITLE
fix(config): return permission denied error when access is missing

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -71,6 +72,9 @@ func NewConfig(tomlConfigPaths []string) (*Config, error) {
 	for _, p := range tomlConfigPaths {
 		s, err := os.Stat(p)
 		if err != nil {
+			if errors.Is(err, os.ErrPermission) {
+				return nil, fmt.Errorf("config: permission denied when accessing path %q: %w", p, err)
+			}
 			continue
 		}
 		if s.IsDir() {


### PR DESCRIPTION
If a permission denied error occurs while checking the provided configuration file or directories, stop command execution and return the corresponding error.