### PR TITLE
Allow using ctrd storage

### DIFF
--- a/cmd/fioup/check.go
+++ b/cmd/fioup/check.go
@@ -30,8 +30,7 @@ func init() {
 		Short: "Update TUF metadata",
 		Args:  cobra.NoArgs,
 		Annotations: map[string]string{
-			lockFlagKey:        "true",
-			requireOverlay2Key: "true",
+			lockFlagKey: "true",
 		},
 	}
 	cmd.Flags().StringVar(&opts.Format, "format", "text", "Format the output. Values: [text | json]")

--- a/cmd/fioup/daemon.go
+++ b/cmd/fioup/daemon.go
@@ -50,8 +50,7 @@ func init() {
 		},
 		Args: cobra.NoArgs,
 		Annotations: map[string]string{
-			lockFlagKey:        "true",
-			requireOverlay2Key: "true",
+			lockFlagKey: "true",
 		},
 	}
 	cmd.Flags().BoolVar(&opts.configEnabled, "fioconfig", true, "Include fioconfig daemon logic.")

--- a/cmd/fioup/fetch.go
+++ b/cmd/fioup/fetch.go
@@ -38,8 +38,7 @@ func init() {
 		},
 		Args: cobra.RangeArgs(0, 1),
 		Annotations: map[string]string{
-			lockFlagKey:        "true",
-			requireOverlay2Key: "true",
+			lockFlagKey: "true",
 		},
 	}
 	rootCmd.AddCommand(cmd)

--- a/cmd/fioup/install.go
+++ b/cmd/fioup/install.go
@@ -18,8 +18,7 @@ func init() {
 		},
 		Args: cobra.NoArgs,
 		Annotations: map[string]string{
-			lockFlagKey:        "true",
-			requireOverlay2Key: "true",
+			lockFlagKey: "true",
 		},
 	}
 	rootCmd.AddCommand(cmd)

--- a/cmd/fioup/root.go
+++ b/cmd/fioup/root.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/docker/docker/client"
 	fioconfig "github.com/foundriesio/fioconfig/app"
 	"github.com/foundriesio/fioconfig/sotatoml"
 	cfg "github.com/foundriesio/fioup/pkg/config"
@@ -21,10 +20,8 @@ import (
 )
 
 const (
-	lockFileName       = "fioup.lock"
-	lockFlagKey        = "lock-flag"
-	requireOverlay2Key = "require-overlay2"
-	overlay2DriverName = "overlay2"
+	lockFileName = "fioup.lock"
+	lockFlagKey  = "lock-flag"
 )
 
 var (
@@ -64,19 +61,6 @@ var (
 			if l := cmd.Annotations[lockFlagKey]; l == "true" {
 				cobra.CheckErr(acquireLock())
 			}
-
-			// If the "require overlay2" flag is set, then check if the Docker storage driver is overlay2
-			if l := cmd.Annotations[requireOverlay2Key]; l == "true" {
-				cli, err := client.NewClientWithOpts(client.FromEnv)
-				cobra.CheckErr(err)
-
-				info, err := cli.Info(cmd.Context())
-				cobra.CheckErr(err)
-				if info.Driver != overlay2DriverName {
-					cobra.CheckErr(fmt.Errorf("overlay2 storage driver is required, detected: %s", info.Driver))
-				}
-				slog.Debug("Detected storage driver", "driver", info.Driver)
-			}
 		},
 	}
 )
@@ -102,7 +86,6 @@ func Execute() error {
 		rootCmd.PersistentPreRun(rootCmd, nil)
 		os.Exit(runDockerCredsHelper())
 	}
-
 	return rootCmd.Execute()
 }
 

--- a/cmd/fioup/start.go
+++ b/cmd/fioup/start.go
@@ -18,8 +18,7 @@ func init() {
 		},
 		Args: cobra.NoArgs,
 		Annotations: map[string]string{
-			lockFlagKey:        "true",
-			requireOverlay2Key: "true",
+			lockFlagKey: "true",
 		},
 	}
 	rootCmd.AddCommand(cmd)

--- a/cmd/fioup/update.go
+++ b/cmd/fioup/update.go
@@ -44,8 +44,7 @@ func init() {
 		},
 		Args: cobra.RangeArgs(0, 1),
 		Annotations: map[string]string{
-			lockFlagKey:        "true",
-			requireOverlay2Key: "true",
+			lockFlagKey: "true",
 		},
 	}
 


### PR DESCRIPTION
Allow using `fioup` with a docker daemon configured to use containerd storage, since composeapp now supports image loading in that case: https://github.com/foundriesio/composeapp/commit/00b0fee68828df3bf13f64450bddd5c36fad061d