### PR TITLE
fix(release-ci): add permission to read gh packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
 
     permissions:
       contents: write
+      packages: read
     runs-on: ${{ matrix.hosts.os }}
 
     steps:


### PR DESCRIPTION
Tiny fix in the release CI job.